### PR TITLE
Owner and leaseholder formset checkboxes

### DIFF
--- a/accounts/data.py
+++ b/accounts/data.py
@@ -7,6 +7,7 @@ DOCUMENT_TYPE_PASSPORT = 120
 DOCUMENT_IDENTITY_CARD = 130
 
 DOCUMENT_TYPE_CHOICES = (
+    ('', _('Tipo de documento')),
     (DOCUMENT_TYPE_CC, 'C.C.'),
     (DOCUMENT_TYPE_CE, 'C.E.'),
     (DOCUMENT_TYPE_PASSPORT, _('Pasaporte')),

--- a/buildings/forms.py
+++ b/buildings/forms.py
@@ -106,6 +106,7 @@ class OwnerForm(forms.ModelForm):
             'phone_number',
             'correspondence_address',
             'email',
+            'is_main',
         )
 
     def __init__(self, *args, **kwargs):

--- a/buildings/forms.py
+++ b/buildings/forms.py
@@ -158,6 +158,7 @@ class LeaseholderForm(forms.ModelForm):
             'mobile_phone',
             'phone_number',
             'email',
+            'is_main',
         )
 
     def __init__(self, *args, **kwargs):

--- a/buildings/templates/buildings/administrative/pets/pet_form.html
+++ b/buildings/templates/buildings/administrative/pets/pet_form.html
@@ -41,6 +41,7 @@
       </div>
 
       <div class="form-group">
+          <p>Picture:</p>
           {% render_field form.picture class+="form-control" %}
           {{ form.picture.errors }}
       </div>

--- a/buildings/templates/buildings/administrative/units/unit_form.html
+++ b/buildings/templates/buildings/administrative/units/unit_form.html
@@ -112,10 +112,30 @@
 
                   <hr>
                   <div class="form-group clearfix">
+                    <div class="clearfix">
+                    <p class="float-right">{% trans '¿Es el propietario principal de la unidad?' %}</p>
+                    </div>
+
+                    <div class="clearfix">
+                      <div class="float-right">
+                        <button type="button" class="btn btn-outline-info jsMainOwnerButton">
+                          {% trans 'Propietario principal' %}
+                        </button>
+                        {% render_field owner_form.is_main class+="ci-main-owner-input" %}
+                      </div>
+                    </div>
+
+                    <div class="clearfix">
+                    <p class="font-weight-light float-right">{% trans 'El propietario principal recibirá las notificaciones para realizar la actualización de datos de la unidad.' %}</p>
+                    </div>
+                  </div>
+
+                  <hr>
+                  <div class="form-group clearfix">
                     <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
                       {% trans 'Eliminar' %}
                     </button>
-                    {% render_field owner_form.DELETE class+="ci-delete-owner_input d-none" %}
+                    {% render_field owner_form.DELETE class+="ci-delete-owner-input d-none" %}
                   </div>
                   <hr>
               </div>
@@ -170,11 +190,33 @@
                   </div>
 
                   <hr>
+
+                  <div class="form-group clearfix">
+                    <div class="clearfix">
+                    <p class="float-right">{% trans '¿Es el propietario principal de la unidad?' %}</p>
+                    </div>
+
+                    <div class="clearfix">
+                      <div class="float-right">
+                        <button type="button" class="btn btn-outline-info jsMainOwnerButton">
+                          {% trans 'Propietario principal' %}
+                        </button>
+                        {% render_field owner_formset.empty_form.is_main class+="ci-main-owner-input" %}
+                      </div>
+                    </div>
+
+                    <div class="clearfix">
+                    <p class="font-weight-light float-right">{% trans 'El propietario principal recibirá las notificaciones para realizar la actualización de datos de la unidad.' %}</p>
+                    </div>
+                  </div>
+
+                  <hr>
+
                   <div class="form-group clearfix">
                     <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
                       {% trans 'Eliminar' %}
                     </button>
-                    {% render_field owner_formset.empty_form.DELETE class+="ci-delete-owner_input d-none" %}
+                    {% render_field owner_formset.empty_form.DELETE class+="ci-delete-owner-input d-none" %}
                   </div>
                   <hr>
               </div>
@@ -325,7 +367,33 @@ $(function() {
     // Action to change delete checkbox value on owner form.
     $('#owner_formset').on('click', '.jsDeleteOwnerButton', function () {
       // Find checkbox input to delete current form in owners formset.
-      $(this).parent().find('.ci-delete-owner_input').click();
+      $(this).parent().find('.ci-delete-owner-input').click();
+    });
+
+    // Action to change main owner checkbox value on owner form.
+    $('#owner_formset').on('click', '.jsMainOwnerButton', function () {
+      // Get clicked button.
+      var main_button = $(this);
+      // Get checkbox input in the cliked button form.
+      var set_main_input = $(this).parent().find('.ci-main-owner-input');
+
+      // Uncheck other main owner buttons in the formset.
+      $("#owner_formset .ci-main-owner-input").each(function(idx, element) {
+        $(element).prop("checked", false);
+        $(element).removeClass('btn-info');
+        $(element).addClass('btn-outline-info');
+      });
+
+      // Remove active class for other main owner buttons.
+      $("#owner_formset .jsMainOwnerButton").each(function(idx, element) {
+        $(element).removeClass('btn-info');
+        $(element).addClass('btn-outline-info');
+      });
+
+      // Check main owner input in the current formset.
+      set_main_input.click()
+      // Add active class (btn-info) to the main button in the current formset.
+      main_button.addClass('btn-info').removeClass('btn-outline-info');
     });
 });
 </script>

--- a/buildings/templates/buildings/administrative/units/unit_form.html
+++ b/buildings/templates/buildings/administrative/units/unit_form.html
@@ -67,51 +67,60 @@
               {% endif %}
               {% render_field owner_form.id %}
               <div data-formset-form>
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_form.name class+="form-control" %}
                       {{ owner_form.name.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field owner_form.last_name class+="form-control" %}
                       {{ owner_form.last_name.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_form.document_type class+="form-control" %}
                       {{ owner_form.document_type.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field owner_form.document_number class+="form-control" %}
                       {{ owner_form.document_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_form.mobile_phone class+="form-control" %}
                       <p class="font-weight-light">{{ owner_form.mobile_phone.help_text }}</p>
                       {{ owner_form.mobile_phone.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group  col-md-6">
                       {% render_field owner_form.phone_number class+="form-control" %}
                       <p class="font-weight-light">{{ owner_form.phone_number.help_text }}</p>
                       {{ owner_form.phone_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_form.correspondence_address class+="form-control" %}
                       <p class="font-weight-light">{{ owner_form.correspondence_address.help_text }}</p>
                       {{ owner_form.correspondence_address.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group  col-md-6">
                       {% render_field owner_form.email class+="form-control" %}
                       {{ owner_form.email.errors }}
                   </div>
+                </div>
 
-                  <hr>
-                  <div class="form-group clearfix">
+                <hr>
+                <div class="row">
+                  <div class="form-group clearfix col-md-6">
                     <div class="clearfix">
                     <p class="float-right">{% trans '¿Es el propietario principal de la unidad?' %}</p>
                     </div>
@@ -131,13 +140,14 @@
                   </div>
 
                   <hr>
-                  <div class="form-group clearfix">
+                  <div class="form-group clearfix col-md-6">
                     <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
                       {% trans 'Eliminar' %}
                     </button>
                     {% render_field owner_form.DELETE class+="ci-delete-owner-input d-none" %}
                   </div>
-                  <hr>
+                </div>
+                <hr>
               </div>
           {% endfor %}
           </div>
@@ -146,52 +156,62 @@
           {% escapescript %}
               <p class="h4">{% trans "Otro propietario" %}</p>
               <div data-formset-form>
-                  <div class="form-group">
+
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.name class+="form-control" %}
                       {{ owner_formset.empty_form.name.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.last_name class+="form-control" %}
                       {{ owner_formset.empty_form.last_name.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.document_type class+="form-control" %}
                       {{ owner_formset.empty_form.document_type.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.document_number class+="form-control" %}
                       {{ owner_formset.empty_form.document_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.mobile_phone class+="form-control" %}
                       <p class="font-weight-light">{{ owner_formset.empty_form.mobile_phone.help_text }}</p>
                       {{ owner_formset.empty_form.mobile_phone.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.phone_number class+="form-control" %}
                       <p class="font-weight-light">{{ owner_formset.empty_form.phone_number.help_text }}</p>
                       {{ owner_formset.empty_form.phone_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.correspondence_address class+="form-control" %}
                       <p class="font-weight-light">{{ owner_formset.empty_form.correspondence_address.help_text }}</p>
                       {{ owner_formset.empty_form.correspondence_address.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field owner_formset.empty_form.email class+="form-control" %}
                       {{ owner_formset.empty_form.email.errors }}
                   </div>
+                </div>
 
-                  <hr>
+                <hr>
 
-                  <div class="form-group clearfix">
+                <div class="row">
+                  <div class="form-group clearfix col-md-6">
                     <div class="clearfix">
                     <p class="float-right">{% trans '¿Es el propietario principal de la unidad?' %}</p>
                     </div>
@@ -212,13 +232,14 @@
 
                   <hr>
 
-                  <div class="form-group clearfix">
+                  <div class="form-group clearfix  col-md-6">
                     <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
                       {% trans 'Eliminar' %}
                     </button>
                     {% render_field owner_formset.empty_form.DELETE class+="ci-delete-owner-input d-none" %}
                   </div>
-                  <hr>
+                </div>
+                <hr>
               </div>
           {% endescapescript %}
           </script>

--- a/buildings/templates/buildings/administrative/units/unit_form.html
+++ b/buildings/templates/buildings/administrative/units/unit_form.html
@@ -110,12 +110,13 @@
                       {{ owner_form.email.errors }}
                   </div>
 
-                  {% if forloop.counter != 1 %}
-                  <div class="form-group">
-                      <label>{% trans "Eliminar" %}</label>
-                      {% render_field owner_form.DELETE %}
+                  <hr>
+                  <div class="form-group clearfix">
+                    <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
+                      {% trans 'Eliminar' %}
+                    </button>
+                    {% render_field owner_form.DELETE class+="ci-delete-owner_input d-none" %}
                   </div>
-                  {% endif %}
                   <hr>
               </div>
           {% endfor %}
@@ -168,9 +169,12 @@
                       {{ owner_formset.empty_form.email.errors }}
                   </div>
 
-                  <div class="form-group">
-                      <label>Eliminar</label>
-                      {% render_field owner_formset.empty_form.DELETE %}
+                  <hr>
+                  <div class="form-group clearfix">
+                    <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
+                      {% trans 'Eliminar' %}
+                    </button>
+                    {% render_field owner_formset.empty_form.DELETE class+="ci-delete-owner_input d-none" %}
                   </div>
                   <hr>
               </div>
@@ -316,6 +320,12 @@ $(function() {
 
     $('#leaseholder_formset').formset({
         animateForms: true
+    });
+
+    // Action to change delete checkbox value on owner form.
+    $('#owner_formset').on('click', '.jsDeleteOwnerButton', function () {
+      // Find checkbox input to delete current form in owners formset.
+      $(this).parent().find('.ci-delete-owner_input').click();
     });
 });
 </script>

--- a/buildings/templates/buildings/administrative/units/unit_form.html
+++ b/buildings/templates/buildings/administrative/units/unit_form.html
@@ -12,7 +12,7 @@
   <form method="post">
   {% csrf_token %}
   {% if form.non_field_errors %}
-      <div class="form-group">
+      <div class="alert alert-warning" role="alert">
           {{ form.non_field_errors }}
       </div>
   {% endif %}
@@ -132,6 +132,7 @@
                         </button>
                         {% render_field owner_form.is_main class+="ci-main-owner-input" %}
                       </div>
+                      <p>{{ owner_form.is_main.errors }}</p>
                     </div>
 
                     <div class="clearfix">
@@ -223,6 +224,7 @@
                         </button>
                         {% render_field owner_formset.empty_form.is_main class+="ci-main-owner-input" %}
                       </div>
+                      <p>{{ owner_formset.empty_form.is_main.errors }}</p>
                     </div>
 
                     <div class="clearfix">

--- a/buildings/templates/buildings/administrative/units/unit_form.html
+++ b/buildings/templates/buildings/administrative/units/unit_form.html
@@ -54,7 +54,7 @@
 
       <p>{% trans "Tiene la posibilidad de registrar varios propietarios por unidad. El primer propietario que registre será el propietario principal." %}</p>
 
-      <div id="owner_formset" data-formset-prefix="{{ owner_formset.prefix }}">
+      <div id="owner_formset" data-formset-prefix="{{ owner_formset.prefix }}" class="ci_UnitFormFormset">
           {% if owner_formset.non_form_errors %}
           <div class="alert alert-warning" role="alert">{{ owner_formset.non_form_errors }}</div>
           {% endif %}
@@ -127,10 +127,10 @@
 
                     <div class="clearfix">
                       <div class="float-right">
-                        <button type="button" class="btn btn-outline-info jsMainOwnerButton">
+                        <button type="button" class="btn btn-outline-info jsMainFormsetButton">
                           {% trans 'Propietario principal' %}
                         </button>
-                        {% render_field owner_form.is_main class+="ci-main-owner-input" %}
+                        {% render_field owner_form.is_main class+="ci-main-formset-input" %}
                       </div>
                       <p>{{ owner_form.is_main.errors }}</p>
                     </div>
@@ -142,10 +142,10 @@
 
                   <hr>
                   <div class="form-group clearfix col-md-6">
-                    <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
+                    <button type="button" class="btn btn-outline-danger float-right jsDeleteFormsetButton">
                       {% trans 'Eliminar' %}
                     </button>
-                    {% render_field owner_form.DELETE class+="ci-delete-owner-input d-none" %}
+                    {% render_field owner_form.DELETE class+="ci-delete-formset-input d-none" %}
                   </div>
                 </div>
                 <hr>
@@ -155,8 +155,8 @@
 
           <script type="form-template" data-formset-empty-form>
           {% escapescript %}
-              <p class="h4">{% trans "Otro propietario" %}</p>
               <div data-formset-form>
+              <p class="h4">{% trans "Otro propietario" %}</p>
 
                 <div class="row">
                   <div class="form-group col-md-6">
@@ -219,10 +219,10 @@
 
                     <div class="clearfix">
                       <div class="float-right">
-                        <button type="button" class="btn btn-outline-info jsMainOwnerButton">
+                        <button type="button" class="btn btn-outline-info jsMainFormsetButton">
                           {% trans 'Propietario principal' %}
                         </button>
-                        {% render_field owner_formset.empty_form.is_main class+="ci-main-owner-input" %}
+                        {% render_field owner_formset.empty_form.is_main class+="ci-main-formset-input" %}
                       </div>
                       <p>{{ owner_formset.empty_form.is_main.errors }}</p>
                     </div>
@@ -235,10 +235,10 @@
                   <hr>
 
                   <div class="form-group clearfix  col-md-6">
-                    <button type="button" class="btn btn-outline-danger float-right jsDeleteOwnerButton">
+                    <button type="button" class="btn btn-outline-danger float-right jsDeleteFormsetButton">
                       {% trans 'Eliminar' %}
                     </button>
-                    {% render_field owner_formset.empty_form.DELETE class+="ci-delete-owner-input d-none" %}
+                    {% render_field owner_formset.empty_form.DELETE class+="ci-delete-formset-input d-none" %}
                   </div>
                 </div>
                 <hr>
@@ -254,7 +254,7 @@
       <hr>
       <h3>{% trans "Datos del arrendatario" %}</h3>
 
-      <div id="leaseholder_formset" data-formset-prefix="{{ leaseholder_formset.prefix }}">
+      <div id="leaseholder_formset" data-formset-prefix="{{ leaseholder_formset.prefix }}" class="ci_UnitFormFormset">
           {% if leaseholder_formset.non_form_errors %}
           <div class="alert alert-warning" role="alert">{{ leaseholder_formset.non_form_errors }}</div>
           {% endif %}
@@ -267,98 +267,168 @@
               {% endif %}
               {% render_field leaseholder_form.id %}
               <div data-formset-form>
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_form.name class+="form-control" %}
                       {{ leaseholder_form.name.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_form.last_name class+="form-control" %}
                       {{ leaseholder_form.last_name.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_form.document_type class+="form-control" %}
                       {{ leaseholder_form.document_type.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_form.document_number class+="form-control" %}
                       {{ leaseholder_form.document_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_form.mobile_phone class+="form-control" %}
                       <p class="font-weight-light">{{ leaseholder_form.mobile_phone.help_text }}</p>
                       {{ leaseholder_form.mobile_phone.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_form.phone_number class+="form-control" %}
                       <p class="font-weight-light">{{ leaseholder_form.phone_number.help_text }}</p>
                       {{ leaseholder_form.phone_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_form.email class+="form-control" %}
                       {{ leaseholder_form.email.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
-                      <label>{% trans "Eliminar" %}</label>
-                      {% render_field leaseholder_form.DELETE %}
+                <hr>
+                <div class="row">
+                  <div class="form-group clearfix col-md-6">
+                    <div class="clearfix">
+                    <p class="float-right">{% trans '¿Es el arrendatario principal de la unidad?' %}</p>
+                    </div>
+
+                    <div class="clearfix">
+                      <div class="float-right">
+                        <button type="button" class="btn btn-outline-info jsMainFormsetButton">
+                          {% trans 'Arrendatario principal' %}
+                        </button>
+                        {% render_field leaseholder_form.is_main class+="ci-main-formset-input" %}
+                      </div>
+                      <p>{{ leaseholder_form.is_main.errors }}</p>
+                    </div>
+
+                    <div class="clearfix">
+                    <p class="font-weight-light float-right">{% trans 'El arrendatario principal recibirá las notificaciones para realizar la actualización de datos.' %}</p>
+                    </div>
                   </div>
+
                   <hr>
+
+                  <div class="form-group clearfix col-md-6">
+                    <button type="button" class="btn btn-outline-danger float-right jsDeleteFormsetButton">
+                      {% trans 'Eliminar' %}
+                    </button>
+                    {% render_field leaseholder_form.DELETE class+="ci-delete-formset-input d-none" %}
+                  </div>
+                </div>
+                <hr>
               </div>
           {% endfor %}
           </div>
 
           <script type="form-template" data-formset-empty-form>
           {% escapescript %}
-              <p class="h4">{% trans "Otro arrendatario" %}</p>
               <div data-formset-form>
-                  <div class="form-group">
+              <p class="h4">{% trans "Otro arrendatario" %}</p>
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_formset.empty_form.name class+="form-control" %}
                       {{ leaseholder_formset.empty_form.name.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_formset.empty_form.last_name class+="form-control" %}
                       {{ leaseholder_formset.empty_form.last_name.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_formset.empty_form.document_type class+="form-control" %}
                       {{ leaseholder_formset.empty_form.document_type.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_formset.empty_form.document_number class+="form-control" %}
                       {{ leaseholder_formset.empty_form.document_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_formset.empty_form.mobile_phone class+="form-control" %}
                       <p class="font-weight-light">{{ leaseholder_formset.empty_form.mobile_phone.help_text }}</p>
                       {{ leaseholder_formset.empty_form.mobile_phone.errors }}
                   </div>
 
-                  <div class="form-group">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_formset.empty_form.phone_number class+="form-control" %}
                       <p class="font-weight-light">{{ leaseholder_formset.empty_form.phone_number.help_text }}</p>
                       {{ leaseholder_formset.empty_form.phone_number.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
+                <div class="row">
+                  <div class="form-group col-md-6">
                       {% render_field leaseholder_formset.empty_form.email class+="form-control" %}
                       {{ leaseholder_formset.empty_form.email.errors }}
                   </div>
+                </div>
 
-                  <div class="form-group">
-                      <label>{% trans "Eliminar" %}</label>
-                      {% render_field leaseholder_formset.empty_form.DELETE %}
+                <hr>
+                <div class="row">
+                  <div class="form-group clearfix col-md-6">
+                    <div class="clearfix">
+                    <p class="float-right">{% trans '¿Es el propietario principal de la unidad?' %}</p>
+                    </div>
+
+                    <div class="clearfix">
+                      <div class="float-right">
+                        <button type="button" class="btn btn-outline-info jsMainFormsetButton">
+                          {% trans 'Arrendatario principal' %}
+                        </button>
+                        {% render_field leaseholder_formset.empty_form.is_main class+="ci-main-formset-input" %}
+                      </div>
+                      <p>{{ leaseholder_formset.empty_form.is_main.errors }}</p>
+                    </div>
+
+                    <div class="clearfix">
+                    <p class="font-weight-light float-right">{% trans 'El arrendatario principal recibirá las notificaciones para realizar la actualización de datos.' %}</p>
+                    </div>
                   </div>
+
                   <hr>
+
+                  <div class="form-group clearfix col-md-6">
+                    <button type="button" class="btn btn-outline-danger float-right jsDeleteFormsetButton">
+                      {% trans 'Eliminar' %}
+                    </button>
+                    {% render_field leaseholder_formset.empty_form.DELETE class+="ci-delete-formset-input d-none" %}
+                  </div>
+                </div>
+                <hr>
               </div>
           {% endescapescript %}
           </script>
@@ -387,33 +457,35 @@ $(function() {
         animateForms: true
     });
 
-    // Action to change delete checkbox value on owner form.
-    $('#owner_formset').on('click', '.jsDeleteOwnerButton', function () {
-      // Find checkbox input to delete current form in owners formset.
-      $(this).parent().find('.ci-delete-owner-input').click();
+    // Action to change delete checkbox value on owner and leaseholder form.
+    $('.ci_UnitFormFormset').on('click', '.jsDeleteFormsetButton', function () {
+      // Find checkbox input to delete current form in owners and leaseholders formset.
+      $(this).parent().find('.ci-delete-formset-input').click();
     });
 
-    // Action to change main owner checkbox value on owner form.
-    $('#owner_formset').on('click', '.jsMainOwnerButton', function () {
+    // Action to change main owner and leaseholder checkboxes value.
+    $('.ci_UnitFormFormset').on('click', '.jsMainFormsetButton', function () {
       // Get clicked button.
       var main_button = $(this);
       // Get checkbox input in the cliked button form.
-      var set_main_input = $(this).parent().find('.ci-main-owner-input');
+      var set_main_input = $(this).parent().find('.ci-main-formset-input');
+      // Get formset id.
+      var formset_id = $(this).closest('.ci_UnitFormFormset').prop('id');
 
       // Uncheck other main owner buttons in the formset.
-      $("#owner_formset .ci-main-owner-input").each(function(idx, element) {
+      $('#' + formset_id + ' .ci-main-formset-input').each(function(idx, element) {
         $(element).prop("checked", false);
         $(element).removeClass('btn-info');
         $(element).addClass('btn-outline-info');
       });
 
-      // Remove active class for other main owner buttons.
-      $("#owner_formset .jsMainOwnerButton").each(function(idx, element) {
+      // Remove active class for other main owner buttons and leaseholder buttons.
+      $('#' + formset_id + ' .jsMainFormsetButton').each(function(idx, element) {
         $(element).removeClass('btn-info');
         $(element).addClass('btn-outline-info');
       });
 
-      // Check main owner input in the current formset.
+      // Check main owner input and leaseholder button in the current formset.
       set_main_input.click()
       // Add active class (btn-info) to the main button in the current formset.
       main_button.addClass('btn-info').removeClass('btn-outline-info');

--- a/buildings/templates/buildings/administrative/units/unit_form.html
+++ b/buildings/templates/buildings/administrative/units/unit_form.html
@@ -130,7 +130,7 @@
                         <button type="button" class="btn btn-outline-info jsMainFormsetButton">
                           {% trans 'Propietario principal' %}
                         </button>
-                        {% render_field owner_form.is_main class+="ci-main-formset-input" %}
+                        {% render_field owner_form.is_main class+="ci-main-formset-input d-none" %}
                       </div>
                       <p>{{ owner_form.is_main.errors }}</p>
                     </div>
@@ -222,7 +222,7 @@
                         <button type="button" class="btn btn-outline-info jsMainFormsetButton">
                           {% trans 'Propietario principal' %}
                         </button>
-                        {% render_field owner_formset.empty_form.is_main class+="ci-main-formset-input" %}
+                        {% render_field owner_formset.empty_form.is_main class+="ci-main-formset-input d-none" %}
                       </div>
                       <p>{{ owner_formset.empty_form.is_main.errors }}</p>
                     </div>
@@ -246,8 +246,8 @@
           {% endescapescript %}
           </script>
 
-          <div>
-              <button class="btn btn-outline-success" type="button" data-formset-add>{% trans "Agregar propietario" %}</button>
+          <div class="clearfix">
+              <button class="btn btn-outline-success float-right" type="button" data-formset-add>{% trans "Agregar propietario" %}</button>
           </div>
       </div>
 
@@ -324,7 +324,7 @@
                         <button type="button" class="btn btn-outline-info jsMainFormsetButton">
                           {% trans 'Arrendatario principal' %}
                         </button>
-                        {% render_field leaseholder_form.is_main class+="ci-main-formset-input" %}
+                        {% render_field leaseholder_form.is_main class+="ci-main-formset-input d-none" %}
                       </div>
                       <p>{{ leaseholder_form.is_main.errors }}</p>
                     </div>
@@ -409,7 +409,7 @@
                         <button type="button" class="btn btn-outline-info jsMainFormsetButton">
                           {% trans 'Arrendatario principal' %}
                         </button>
-                        {% render_field leaseholder_formset.empty_form.is_main class+="ci-main-formset-input" %}
+                        {% render_field leaseholder_formset.empty_form.is_main class+="ci-main-formset-input d-none" %}
                       </div>
                       <p>{{ leaseholder_formset.empty_form.is_main.errors }}</p>
                     </div>
@@ -433,8 +433,8 @@
           {% endescapescript %}
           </script>
 
-          <div>
-              <button class="btn btn-outline-success" type="button" data-formset-add>{% trans "Agregar arrendatario" %}</button>
+          <div class="clearfix">
+              <button class="btn btn-outline-success float-right" type="button" data-formset-add>{% trans "Agregar arrendatario" %}</button>
           </div>
       </div>
       <hr>
@@ -456,6 +456,14 @@ $(function() {
     $('#leaseholder_formset').formset({
         animateForms: true
     });
+
+    // Add active class to 'is_main' button is related field is checked on formset.
+    $('.ci_UnitFormFormset .ci-main-formset-input').each(function(idx, element) {
+      if (element.checked) {
+        $(element).parent().find('.jsMainFormsetButton').addClass('btn-info').removeClass('btn-outline-info');
+      }
+    });
+
 
     // Action to change delete checkbox value on owner and leaseholder form.
     $('.ci_UnitFormFormset').on('click', '.jsDeleteFormsetButton', function () {

--- a/buildings/utils.py
+++ b/buildings/utils.py
@@ -16,7 +16,7 @@ def validate_is_main_formset(form, formset, formset_type):
 
     for formset_form in formset:
         # Get the 'is_main' input value.
-        is_main = formset_form.cleaned_data['is_main']
+        is_main = formset_form.cleaned_data.get('is_main')
 
         if is_main:
             # If 'is_main' field is checker, the counter records it.
@@ -57,20 +57,10 @@ def process_unit_formset(formset, unit):
     Post data for owner formset and for leasehodler data
     is processed by this function.
     """
-    # TODO: Provisionally added to add a main leaseholder
-    # and a main owner to the unit. Should be added via
-    # form fields. Added only because QA team needs it
-    # soon. I will update it next days.
-    i = 0
     for form in formset:
-        i += 1
         if form.is_valid():
             instance = form.save(commit=False)
             instance.unit = unit
-
-            if i == 1:
-                instance.is_main = True
-
             instance.save()
 
             delete = form.cleaned_data['DELETE']

--- a/buildings/utils.py
+++ b/buildings/utils.py
@@ -1,5 +1,55 @@
 # Utils for building app functionalities.
 
+from django.utils.translation import ugettext as _
+
+
+def validate_is_main_formset(form, formset, formset_type):
+    """
+    Function created to validate the 'is main' field in
+    owners formset and in leaseholders formset. Only one
+    form in the formset must has the 'is_main' input checked.
+    """
+
+    # This variable records the number of forms with the
+    # 'is_main' field checker.
+    is_main_counter = 0
+
+    for formset_form in formset:
+        # Get the 'is_main' input value.
+        is_main = formset_form.cleaned_data['is_main']
+
+        if is_main:
+            # If 'is_main' field is checker, the counter records it.
+            is_main_counter += 1
+
+            # If there are more than one form with the 'is_main'
+            # checked, an error is added to the current form in
+            # the formset.
+            if is_main_counter > 1:
+                # Add error if there are more than one 'is_main' input checked.
+                if formset_type == 'owner':
+                    # Error message for owner formset.
+                    error = _('La unidad debe tener solo 1'
+                              ' propietario principal.')
+                elif formset_type == 'leaseholder':
+                    # Error message for leaseholder formset.
+                    error = _('La unidad debe tener solo 1'
+                              ' arrendatario principal.')
+                formset_form.add_error(
+                    'is_main', error,
+                )
+
+    # Units must have one main owner. If there are not owners,
+    # an error is added to the unit form. If the formset type is
+    # leaseholder, a minimum number of 'is_main' checked inputs is
+    # not required.
+    if is_main_counter == 0 and formset_type == 'owner':
+        form.add_error(
+            None, _('Asigne al menos un propietario principal.')
+        )
+
+    return (form, formset, is_main_counter)
+
 
 def process_unit_formset(formset, unit):
     """

--- a/buildings/views/units.py
+++ b/buildings/views/units.py
@@ -290,6 +290,40 @@ class UnitUpdateView(CustomUserMixin, TemplateView):
                 )
             )
 
+        # Validate the number of form with 'is_main' field
+        # checked. If there are not forms checked or there
+        # are more than one, an error message must be raised.
+        #  Units must have one main owner.
+        form, owner_formset, is_main_owner_counter = validate_is_main_formset(
+            form=form,
+            formset=owner_formset,
+            formset_type='owner',
+        )
+
+        # Validate the number of form with 'is_main' field
+        # checked. If there  are more than one, an error
+        # message must be raised. Units must have only one
+        # main leaseholder.
+        form, leaseholder_formset, is_main_leaseholder_counter = validate_is_main_formset(
+            form=form,
+            formset=leaseholder_formset,
+            formset_type='leaseholder',
+        )
+
+        # Return formsets errors.
+        if (
+            not is_main_owner_counter or
+            is_main_owner_counter > 1 or
+            is_main_leaseholder_counter > 1
+        ):
+            return self.render_to_response(
+                self.get_context_data(
+                    form=form,
+                    owner_formset=owner_formset,
+                    leaseholder_formset=leaseholder_formset,
+                )
+            )
+
         # Save unit form data.
         unit = form.save()
         # Update, delete or create new Owner instances for this unit.

--- a/buildings/views/units.py
+++ b/buildings/views/units.py
@@ -166,7 +166,7 @@ class UnitFormView(CustomUserMixin, TemplateView):
         form, leaseholder_formset, is_main_leaseholder_counter = validate_is_main_formset(
             form=form,
             formset=leaseholder_formset,
-            formset_type='owner',
+            formset_type='leaseholder',
         )
 
         # Return formsets errors.


### PR DESCRIPTION
Units must have only one main owner and one main leaseholder. Here, the "is_main" field validations have been added to the owners formset and to the leaseholders formset. Bakcend validation (Python side) and front end validations have been developed.

"is_main" and "delete" checkboxes have been hidden, and they are now managed by new nice buttons that, by using javascript, update the checkboxes value.